### PR TITLE
Improving the URL match/extract

### DIFF
--- a/src/validators/crypto.rs
+++ b/src/validators/crypto.rs
@@ -21,7 +21,7 @@ lazy_static! {
     static ref XRP: Regex = Regex::new(r"(?i)^[rx](?=\S*?\d\S*?\b)[0-9a-zA-Z]{33,47}\b").unwrap();
 
     /// Incase of Illegal chars for a Crypto Wallet
-    static ref ILLEGAL_CHARS: Vec<String> = vec![
+    static ref ILLEGAL_CHARS: Vec<String> = [
         '.', '!', '%', '*', '$', '#', '@', ')', '(', '^', '`', '~', '|',
         '>', '<', '-', '_', '"', '\\', '}', '{', ':', ';', ',', '/', '?',
     ]

--- a/src/validators/internet.rs
+++ b/src/validators/internet.rs
@@ -192,6 +192,14 @@ pub fn is_url(value: &str) -> bool {
     URL.is_match(value).unwrap_or_default()
 }
 
+pub fn get_url(value: &str) -> Option<String> {
+    //! Extracts the URL from a given string.
+    let val = URL
+        .find(value)
+        .expect("Regex failed to operate on input!")?;
+    Some(val.as_str().to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -267,5 +275,37 @@ mod tests {
         assert!(!is_url("abc.com"));
         assert!(!is_url("localhost"));
         assert!(!is_url("localhost:9455"));
+    }
+
+    #[test]
+    fn test_get_url() {
+        assert_eq!(
+            get_url("https://www.example.com").unwrap(),
+            "https://www.example.com"
+        );
+        assert_eq!(
+            get_url("https://example.com").unwrap(),
+            "https://example.com"
+        );
+        assert_eq!(
+            get_url("https://example.co.uk").unwrap(),
+            "https://example.co.uk"
+        );
+        assert_eq!(
+            get_url("http://www.example.co.uk").unwrap(),
+            "http://www.example.co.uk"
+        );
+        assert_eq!(
+            get_url("https://localhost:8443").unwrap(),
+            "https://localhost:8443"
+        );
+        assert_eq!(get_url("http://localhost").unwrap(), "http://localhost");
+        assert_eq!(get_url("http://清华大学.cn").unwrap(), "http://清华大学.cn");
+
+        assert_eq!(
+            get_url("foo:https://example.com").unwrap(),
+            "https://example.com"
+        );
+        assert_eq!(get_url("abc.com"), None);
     }
 }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -80,8 +80,8 @@ pub fn by_whitespace(s: String) -> WhitespaceResult {
             crypto_address.push(format!("{} - {}", x, which_cryptocurrency(x).unwrap()))
         } else if internet::is_domain(x) {
             domains.push(x.to_string())
-        } else if internet::is_url(x) {
-            urls.push(x.to_string())
+        } else if let Some(url) = internet::get_url(x) {
+            urls.push(url)
         } else if internet::is_email(x, None) {
             emails.push(x.to_string())
         } else if system::is_regex(x) {


### PR DESCRIPTION
I found when using the URL matcher it'd do things slightly weird, example string was:

```
foo:hxxps://example.com/bar
```

Which technically matched because of the `$` tail-anchor but also included the `foo:` which was invalid - I've updated the match/extraction to fix this slightly.